### PR TITLE
Fix loading of Settings -> Extensions into editor

### DIFF
--- a/main/display/3dprinter/marlin/settings_screen.cpp
+++ b/main/display/3dprinter/marlin/settings_screen.cpp
@@ -294,7 +294,7 @@ void event_button_edit_serial_baud_rate_cb(lv_event_t *e) {
 
 void event_button_edit_extensions_cb(lv_event_t *e) {
   esp3d_log("Show component");
-  const char *text = (const char *)lv_event_get_user_data(e);
+  const char *text = (const char *)lv_label_get_text(extensions_label);
   textEditor::create_text_editor(lv_scr_act(), text, extensions_edit_done_cb);
 }
 
@@ -373,8 +373,7 @@ void settings_screen() {
     lv_obj_t *btnEdit =
         listLine::add_button_to_line(LV_SYMBOL_EDIT, line_container);
     lv_obj_add_event_cb(btnEdit, event_button_edit_extensions_cb,
-                        LV_EVENT_CLICKED,
-                        (void *)(lv_label_get_text(extensions_label)));
+                        LV_EVENT_CLICKED, NULL);
   }
 
 #if ESP3D_USB_SERIAL_FEATURE


### PR DESCRIPTION
This is a bug fix for another minor issue I found.

I noticed that when going to the Settings screen and then clicking on the Edit button for Extensions that the value loaded into the editor was mangled.  Leaving this screen then saved the wrong value.

I believe this is because the extensions label is being loaded async so `lv_label_get_text(extensions_label)` doesn't actually have a valid value when the button handler is wired up (`lv_obj_add_event_cb`).  Just moving `lv_label_get_text(extensions_label)` into the event handler seems to fix the issue, but obviously feel free to fix this a different way if needed.