### PR TITLE
Performance Improvement for ESP32_2432S028R with PSRAM mod

### DIFF
--- a/hardware/ESP32_2432S028R/components/bsp/bsp.c
+++ b/hardware/ESP32_2432S028R/components/bsp/bsp.c
@@ -38,11 +38,6 @@
 /*********************
  *      DEFINES
  *********************/
-#if WITH_PSRAM
-  #define LV_BUF_MALLOC_TYPE  MALLOC_CAP_SPIRAM
-#else
-  #define LV_BUF_MALLOC_TYPE  MALLOC_CAP_DMA
-#endif  // WITH_PSRAM
 
 /**********************
  *      TYPEDEFS
@@ -67,7 +62,7 @@
 esp_err_t bsp_init(void) {
 #if ESP3D_DISPLAY_FEATURE
   // Driver initialization
-  esp3d_log("Display buffer size: %d", DISP_BUF_SIZE);
+  esp3d_log("Display buffer size: %1.2f KB", DISP_BUF_SIZE * sizeof(lv_color_t) / 1024.0);
 
   /* Display controller initialization */
   esp3d_log("Initializing SPI master for display");
@@ -108,7 +103,7 @@ esp_err_t bsp_init(void) {
   // Lvgl setup
   esp3d_log("Setup Lvgl");
   lv_color_t *buf1 = (lv_color_t *)heap_caps_malloc(
-      DISP_BUF_SIZE * sizeof(lv_color_t), LV_BUF_MALLOC_TYPE);
+      DISP_BUF_SIZE * sizeof(lv_color_t), DISP_BUF_MALLOC_TYPE);
   if (buf1 == NULL) {
     esp3d_log_e("Failed to allocate LVGL draw buffer 1");
     return ESP_FAIL;
@@ -118,7 +113,7 @@ esp_err_t bsp_init(void) {
   lv_color_t *buf2 = NULL;
 #if DISP_USE_DOUBLE_BUFFER
   buf2 = (lv_color_t *)heap_caps_malloc(DISP_BUF_SIZE * sizeof(lv_color_t),
-                                        LV_BUF_MALLOC_TYPE);
+                                        DISP_BUF_MALLOC_TYPE);
   if (buf2 == NULL) {
     esp3d_log_e("Failed to allocate LVGL draw buffer 2");
     return ESP_FAIL;

--- a/hardware/ESP32_2432S028R/components/bsp/disp_def.h
+++ b/hardware/ESP32_2432S028R/components/bsp/disp_def.h
@@ -10,15 +10,22 @@ extern "C" {
 #define DISP_HOR_RES_MAX 320
 #define DISP_VER_RES_MAX 240
 
-// 1/10
-#define DISP_BUF_SIZE (DISP_HOR_RES_MAX * 10)
+#if WITH_PSRAM
+  // 1/10 (24-line) buffer (15KB) in external PSRAM
+  #define DISP_BUF_SIZE (DISP_HOR_RES_MAX * DISP_VER_RES_MAX / 10)
+  #define DISP_BUF_MALLOC_TYPE  MALLOC_CAP_SPIRAM
+#else
+  // 1/24 (10-line) buffer (6.25KB) in internal DRAM
+  #define DISP_BUF_SIZE (DISP_HOR_RES_MAX * 10)
+  #define DISP_BUF_MALLOC_TYPE  MALLOC_CAP_DMA
+#endif  // WITH_PSRAM
+
+#define DISP_USE_DOUBLE_BUFFER 1
 
 #define ILI9341_DC 2             // GPIO 2
 #define ILI9341_USE_RST 1        // Flag
 #define ILI9341_RST 4            // GPIO 4
 #define ILI9341_INVERT_COLORS 0  // Flag
-
-#define DISP_USE_DOUBLE_BUFFER 1
 
 /*
 PORTRAIT				0

--- a/hardware/ESP32_2432S028R/components/bsp/lv_conf.h
+++ b/hardware/ESP32_2432S028R/components/bsp/lv_conf.h
@@ -46,14 +46,15 @@
  *=========================*/
 
 /*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
-#define LV_MEM_CUSTOM 0
+#if WITH_PSRAM
+  #define LV_MEM_CUSTOM 1
+#else
+  #define LV_MEM_CUSTOM 0
+#endif  // WITH_PSRAM
+
 #if LV_MEM_CUSTOM == 0
 /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-#if WITH_PSRAM
-  #define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
-#else
-  #define LV_MEM_SIZE (12U * 1024U)          /*[bytes]*/
-#endif  // WITH_PSRAM
+#define LV_MEM_SIZE (12U * 1024U)          /*[bytes]*/
 
 /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
 #define LV_MEM_ADR 0     /*0: unused*/


### PR DESCRIPTION
This increases the DISP_BUF_SIZE for the PSRAM variant, and allows LVGL to dynamically allocate out of PSRAM instead of using a set block of internal DRAM.

This appears to increase the FPS on the SD file listing screen and decrease the CPU utilization on most screens (but especially on screens with fairly static content).  This target is pretty much getting full 33 FPS on all screens now, except while actively scrolling lists.  It is noticeably less laggy as well.

This also frees up a bunch more internal DRAM for other future uses.