### PR TITLE
Convert ILI9341 driver to use esp_lcd like the others

### DIFF
--- a/hardware/ESP32_2432S028R/components/bsp/CMakeLists.txt
+++ b/hardware/ESP32_2432S028R/components/bsp/CMakeLists.txt
@@ -2,5 +2,5 @@
 idf_component_register(
     SRCS "bsp.c"
     INCLUDE_DIRS .
-    REQUIRES esp3d_log lvgl spi_bus disp_spi ili9341 sw_spi xpt2046 disp_backlight
+    REQUIRES esp3d_log lvgl spi_bus ili9341 sw_spi xpt2046 disp_backlight
 )

--- a/hardware/ESP32_2432S028R/components/bsp/disp_def.h
+++ b/hardware/ESP32_2432S028R/components/bsp/disp_def.h
@@ -8,7 +8,6 @@ extern "C" {
 #define TFT_DISPLAY_CONTROLLER "ILI9341"
 
 #include "spi_bus.h"
-#include "disp_spi.h"
 #include "ili9341.h"
 #include "disp_backlight.h"
 
@@ -36,15 +35,16 @@ LANDSCAPE_INVERTED      3
   #define DISP_BUF_SIZE (DISP_HOR_RES_MAX * DISP_VER_RES_MAX / 10)
   #define DISP_BUF_MALLOC_TYPE  MALLOC_CAP_SPIRAM
 #else
-  // 1/24 (10-line) buffer (6.25KB) in internal DRAM
-  #define DISP_BUF_SIZE (DISP_HOR_RES_MAX * 10)
+  // 1/20 (12-line) buffer (7.5KB) in internal DRAM
+  #define DISP_BUF_SIZE (DISP_HOR_RES_MAX * 12)
   #define DISP_BUF_MALLOC_TYPE  MALLOC_CAP_DMA
 #endif  // WITH_PSRAM
 #define DISP_BUF_SIZE_BYTES    (DISP_BUF_SIZE * 2)
 
-ili9341_config_t ili9341_cfg = {
-    .rst_pin = 4, // GPIO 4
-    .dc_pin = 2, // GPIO 2
+esp_lcd_panel_dev_config_t disp_panel_cfg = {
+    .reset_gpio_num = 4, // GPIO 4
+    .color_space = ESP_LCD_COLOR_SPACE_BGR,
+    .bits_per_pixel = 16,
 };
 
 // SPI (dedicated)
@@ -55,11 +55,14 @@ ili9341_config_t ili9341_cfg = {
 #define DISP_SPI_MOSI 13  // GPIO 13
 //#define DISP_SPI_MISO 12  // GPIO 12
 
-spi_device_interface_config_t disp_spi_cfg = {
-    .clock_speed_hz = 40 * 1000 * 1000,
-    .mode = 0,
-    .spics_io_num = 15, // GPIO 15
-    .input_delay_ns = 0,
+esp_lcd_panel_io_spi_config_t disp_spi_cfg = {
+    .dc_gpio_num = 2, // GPIO 2
+    .cs_gpio_num = 15, // GPIO 15
+    .pclk_hz = 40 * 1000 * 1000,
+    .lcd_cmd_bits = 8,
+    .lcd_param_bits = 8,
+    .spi_mode = 0,
+    .trans_queue_depth = 10,
 };
 
 #define DISP_BCKL_DEFAULT_DUTY 100  //%

--- a/hardware/common/components/ili9341/CMakeLists.txt
+++ b/hardware/common/components/ili9341/CMakeLists.txt
@@ -4,5 +4,5 @@ set(INCLUDES .)
 idf_component_register(
     SRCS ${SOURCES}
     INCLUDE_DIRS ${INCLUDES}
-    REQUIRES esp3d_log disp_spi
+    REQUIRES esp3d_log esp_lcd driver
 )

--- a/hardware/common/components/ili9341/ili9341.c
+++ b/hardware/common/components/ili9341/ili9341.c
@@ -1,198 +1,302 @@
 /**
  * @file ili9341.c
- *
  */
 
-/*********************
- *      INCLUDES
- *********************/
-#include "ili9341.h"
-#include "disp_spi.h"
-#include <driver/gpio.h>
-#include "esp3d_log.h"
+#include <stdlib.h>
+#include <sys/cdefs.h>
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-
-/*********************
- *      DEFINES
- *********************/
+#include <driver/gpio.h>
+#include "esp3d_log.h"
+#include "esp_check.h"
+#include "ili9341.h"
 
 /**********************
  *      TYPEDEFS
  **********************/
 
-/*The LCD needs a bunch of command/argument values to be initialized. They are stored in this struct. */
 typedef struct {
-    uint8_t cmd;
-    uint8_t data[16];
-    uint8_t databytes; //No of data in data; bit 7 = delay after set; 0xFF = end of cmds.
-} lcd_init_cmd_t;
+  esp_lcd_panel_t base;
+  esp_lcd_panel_io_handle_t io;
+  int reset_gpio_num;
+  bool reset_level;
+  int x_gap;
+  int y_gap;
+  unsigned int bits_per_pixel;
+  uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
+  uint8_t colmod_cal; // save current value of LCD_CMD_COLMOD register
+} lcd_panel_t;
+
+/* The LCD needs a bunch of command/argument values to be initialized. They are stored in this struct. */
+typedef struct {
+  uint8_t cmd;
+  uint8_t data[16];
+  uint8_t num_bytes; // Number of data bytes; 0xFF = end of cmds.
+} lcd_cmd_t;
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 
-static void ili9341_send_cmd(uint8_t cmd);
-static void ili9341_send_data(void * data, uint16_t length);
-static void ili9341_send_color(void * data, uint16_t length);
-
-/**********************
- *  STATIC VARIABLES
- **********************/
-static const ili9341_config_t *ili9341_config = NULL;
-
-/**********************
- *      MACROS
- **********************/
+static esp_err_t lcd_panel_del(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_reset(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_init(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data);
+static esp_err_t lcd_panel_invert_color(esp_lcd_panel_t *panel, bool invert_color_data);
+static esp_err_t lcd_panel_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
+static esp_err_t lcd_panel_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
+static esp_err_t lcd_panel_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
+static esp_err_t lcd_panel_disp_on_off(esp_lcd_panel_t *panel, bool off);
 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
 
-esp_err_t ili9341_init(const ili9341_config_t *config) {
-  if (config == NULL) {
-      return ESP_ERR_INVALID_ARG;
-  }
-  ili9341_config = config;
+esp_err_t esp_lcd_new_panel_ili9341(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel) {
+  esp_err_t ret = ESP_OK;
+  lcd_panel_t *lcd_panel = NULL;
+  ESP_GOTO_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, err, "", "invalid argument");
+  lcd_panel = calloc(1, sizeof(lcd_panel_t));
+  ESP_GOTO_ON_FALSE(lcd_panel, ESP_ERR_NO_MEM, err, "", "no mem for ili9341 panel");
 
-	lcd_init_cmd_t ili_init_cmds[] = {
-		{0xCF, {0x00, 0x83, 0X30}, 3},
-		{0xED, {0x64, 0x03, 0X12, 0X81}, 4},
-		{0xE8, {0x85, 0x01, 0x79}, 3},
-		{0xCB, {0x39, 0x2C, 0x00, 0x34, 0x02}, 5},
-		{0xF7, {0x20}, 1},
-		{0xEA, {0x00, 0x00}, 2},
-		{0xC0, {0x26}, 1},          /*Power control*/
-		{0xC1, {0x11}, 1},          /*Power control */
-		{0xC5, {0x35, 0x3E}, 2},    /*VCOM control*/
-		{0xC7, {0xBE}, 1},          /*VCOM control*/
-		{0x36, {0x28}, 1},          /*Memory Access Control*/
-		{0x3A, {0x55}, 1},			    /*Pixel Format Set*/
-		{0xB1, {0x00, 0x1B}, 2},
-		{0xF2, {0x08}, 1},
-		{0x26, {0x01}, 1},
-		{0xE0, {0x1F, 0x1A, 0x18, 0x0A, 0x0F, 0x06, 0x45, 0X87, 0x32, 0x0A, 0x07, 0x02, 0x07, 0x05, 0x00}, 15},
-		{0XE1, {0x00, 0x25, 0x27, 0x05, 0x10, 0x09, 0x3A, 0x78, 0x4D, 0x05, 0x18, 0x0D, 0x38, 0x3A, 0x1F}, 15},
-		{0x2A, {0x00, 0x00, 0x00, 0xEF}, 4},
-		{0x2B, {0x00, 0x00, 0x01, 0x3f}, 4},
-		{0x2C, {0}, 0},
-		{0xB7, {0x07}, 1},
-		{0xB6, {0x0A, 0x82, 0x27, 0x00}, 4},
-		{0x11, {0}, 0x80},
-		{0x29, {0}, 0x80},
-		{0, {0}, 0xff},
-	};
-
-	// Initialize non-SPI GPIOs
-  esp_rom_gpio_pad_select_gpio(config->dc_pin);
-	gpio_set_direction(config->dc_pin, GPIO_MODE_OUTPUT);
-
-	if (GPIO_IS_VALID_OUTPUT_GPIO(config->rst_pin)) {
-    esp_rom_gpio_pad_select_gpio(config->rst_pin);
-		gpio_set_direction(config->rst_pin, GPIO_MODE_OUTPUT);
-
-		//  the display
-		gpio_set_level(config->rst_pin, 0);
-		vTaskDelay(100 / portTICK_PERIOD_MS);
-		gpio_set_level(config->rst_pin, 1);
-		vTaskDelay(100 / portTICK_PERIOD_MS);
-	}
-
-	esp3d_log("Initialization.");
-
-	// Send all the commands
-	uint16_t cmd = 0;
-	while (ili_init_cmds[cmd].databytes!=0xff) {
-		ili9341_send_cmd(ili_init_cmds[cmd].cmd);
-		ili9341_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
-		if (ili_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_PERIOD_MS);
-		}
-		cmd++;
-	}
-
-	return ESP_OK;
-}
-
-void ili9341_draw_bitmap(int x_start, int y_start, int x_end, int y_end, const void *color_data) {
-	uint8_t data[4];
-
-	/* Column addresses */
-	ili9341_send_cmd(0x2A);
-	data[0] = (x_start >> 8) & 0xFF;
-	data[1] = x_start & 0xFF;
-	data[2] = ((x_end-1) >> 8) & 0xFF;
-	data[3] = (x_end-1) & 0xFF;
-	ili9341_send_data(data, 4);
-
-	/* Page addresses */
-	ili9341_send_cmd(0x2B);
-	data[0] = (y_start >> 8) & 0xFF;
-	data[1] = y_start & 0xFF;
-	data[2] = ((y_end-1) >> 8) & 0xFF;
-	data[3] = (y_end-1) & 0xFF;
-	ili9341_send_data(data, 4);
-
-	/* Memory write */
-	ili9341_send_cmd(0x2C);
-	uint32_t size = (x_end - x_start) * (y_end - y_start) * 2;	
-	ili9341_send_color((void*)color_data, size);	
-}
-
-void ili9341_sleep_in() {
-	uint8_t data[] = {0x08};
-	ili9341_send_cmd(0x10);
-	ili9341_send_data(&data, 1);
-}
-
-void ili9341_sleep_out() {
-	uint8_t data[] = {0x08};
-	ili9341_send_cmd(0x11);
-	ili9341_send_data(&data, 1);
-}
-
-void ili9341_set_invert_color(bool invert) {
-	if (invert)
- 		ili9341_send_cmd(0x21);
-	else
-	 	ili9341_send_cmd(0x20);
-}
-
-void ili9341_set_orientation(uint8_t orientation) {
-    // ESP_ASSERT(orientation < 4);
-#if ESP3D_TFT_LOG
-    const char *orientation_str[] = {
-        "PORTRAIT", "PORTRAIT_INVERTED", "LANDSCAPE", "LANDSCAPE_INVERTED"
+  if (panel_dev_config->reset_gpio_num >= 0) {
+    gpio_config_t io_conf = {
+        .mode = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = 1ULL << panel_dev_config->reset_gpio_num,
     };
-#endif //ESP3D_TFT_LOG
-    esp3d_log("Display orientation: %s", orientation_str[orientation]);
+    ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, "", "configure GPIO for RST line failed");
+  }
 
-    uint8_t data[] = {0x48, 0x88, 0x28, 0xE8};
+  switch (panel_dev_config->color_space) {
+    case ESP_LCD_COLOR_SPACE_RGB:
+      lcd_panel->madctl_val = 0;
+      break;
+    case ESP_LCD_COLOR_SPACE_BGR:
+      lcd_panel->madctl_val |= LCD_CMD_BGR_BIT;
+      break;
+    default:
+      ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported color space");
+      break;
+  }
 
-    esp3d_log("0x36 command value: 0x%02X", data[orientation]);
+  switch (panel_dev_config->bits_per_pixel) {
+    case 16:
+      lcd_panel->colmod_cal = 0x55;
+      break;
+    case 18:
+      lcd_panel->colmod_cal = 0x66;
+      break;
+    default:
+      ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported pixel width");
+      break;
+  }
 
-    ili9341_send_cmd(0x36);
-    ili9341_send_data((void *) &data[orientation], 1);
+  lcd_panel->io = io;
+  lcd_panel->bits_per_pixel = panel_dev_config->bits_per_pixel;
+  lcd_panel->reset_gpio_num = panel_dev_config->reset_gpio_num;
+  lcd_panel->reset_level = panel_dev_config->flags.reset_active_high;
+  lcd_panel->base.del = lcd_panel_del;
+  lcd_panel->base.reset = lcd_panel_reset;
+  lcd_panel->base.init = lcd_panel_init;
+  lcd_panel->base.draw_bitmap = lcd_panel_draw_bitmap;
+  lcd_panel->base.invert_color = lcd_panel_invert_color;
+  lcd_panel->base.set_gap = lcd_panel_set_gap;
+  lcd_panel->base.mirror = lcd_panel_mirror;
+  lcd_panel->base.swap_xy = lcd_panel_swap_xy;
+  lcd_panel->base.disp_on_off = lcd_panel_disp_on_off;
+  *ret_panel = &(lcd_panel->base);
+  esp3d_log("new ili9341 panel @%p", lcd_panel);
+
+  return ESP_OK;
+
+err:
+  if (lcd_panel) {
+    if (panel_dev_config->reset_gpio_num >= 0) {
+      gpio_reset_pin(panel_dev_config->reset_gpio_num);
+    }
+    free(lcd_panel);
+  }
+  return ret;
 }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
 
-static void ili9341_send_cmd(uint8_t cmd) {
-    disp_wait_for_pending_transactions();
-    gpio_set_level(ili9341_config->dc_pin, 0);	 /*Command mode*/
-    disp_spi_send_data(&cmd, 1);
+static esp_err_t lcd_panel_del(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+
+  if (lcd_panel->reset_gpio_num >= 0) {
+    gpio_reset_pin(lcd_panel->reset_gpio_num);
+  }
+  esp3d_log("del ili9341 panel @%p", lcd_panel);
+  free(lcd_panel);
+  return ESP_OK;
 }
 
-static void ili9341_send_data(void * data, uint16_t length) {
-    disp_wait_for_pending_transactions();
-    gpio_set_level(ili9341_config->dc_pin, 1);	 /*Data mode*/
-    disp_spi_send_data(data, length);
+static esp_err_t lcd_panel_reset(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+
+  // perform hardware reset
+  if (lcd_panel->reset_gpio_num >= 0) {
+    gpio_set_level(lcd_panel->reset_gpio_num, lcd_panel->reset_level);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    gpio_set_level(lcd_panel->reset_gpio_num, !lcd_panel->reset_level);
+    vTaskDelay(pdMS_TO_TICKS(10));
+  } else { // perform software reset
+    esp_lcd_panel_io_tx_param(io, LCD_CMD_SWRESET, NULL, 0);
+    vTaskDelay(pdMS_TO_TICKS(20)); // spec, wait at least 5 ms. before sending new command
+  }
+
+  return ESP_OK;
 }
 
-static void ili9341_send_color(void * data, uint16_t length) {
-    disp_wait_for_pending_transactions();
-    gpio_set_level(ili9341_config->dc_pin, 1);   /*Data mode*/
-    disp_spi_send_colors(data, length);
+static esp_err_t lcd_panel_init(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+
+  // LCD goes into sleep mode and display will be turned off after power on reset, exit sleep mode first
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_SLPOUT, NULL, 0);
+  vTaskDelay(pdMS_TO_TICKS(100));
+
+  lcd_cmd_t vendor_init_cmds[] = {
+    {0xCF, {0x00, 0x83, 0X30}, 3},              // Power control B
+    {0xED, {0x64, 0x03, 0X12, 0X81}, 4},        // Power on sequence control
+    {0xE8, {0x85, 0x01, 0x79}, 3},              // Driver timing control A
+    {0xCB, {0x39, 0x2C, 0x00, 0x34, 0x02}, 5},  // Power control A
+    {0xF7, {0x20}, 1},                          // Pump ratio control
+    {0xEA, {0x00, 0x00}, 2},                    // Driver timing control B
+    {0xC0, {0x26}, 1},                          // Power Control 1
+    {0xC1, {0x11}, 1},                          // Power Control 2
+    {0xC5, {0x35, 0x3E}, 2},                    // VCOM Control 1
+    {0xC7, {0xBE}, 1},                          // VCOM Control 2
+    {0xB1, {0x00, 0x1B}, 2},                    // Frame Rate Control (In Normal Mode/Full Colors)
+    {0xF2, {0x08}, 1},                          // Enable 3G (3 gamma control)
+    {0x26, {0x01}, 1},                          // Gamma Set
+    {0xE0, {0x1F, 0x1A, 0x18, 0x0A, 0x0F, 0x06, 0x45, 0X87, 0x32, 0x0A, 0x07, 0x02, 0x07, 0x05, 0x00}, 15}, // Positive Gamme Correction
+    {0XE1, {0x00, 0x25, 0x27, 0x05, 0x10, 0x09, 0x3A, 0x78, 0x4D, 0x05, 0x18, 0x0D, 0x38, 0x3A, 0x1F}, 15}, // Negative Gamme Correction
+    {0xB7, {0x07}, 1},                          // Entry Mode Set
+    {0xB6, {0x0A, 0x82, 0x27, 0x00}, 4},        // Display Function Control
+    {0, {0}, 0xFF},                             // NOP
+  };
+
+  // Send all the vendor init commands
+  uint8_t i = 0;
+  while (vendor_init_cmds[i].num_bytes != 0xFF) {
+    esp_lcd_panel_io_tx_param(io, vendor_init_cmds[i].cmd, vendor_init_cmds[i].data, vendor_init_cmds[i].num_bytes);
+    i++;
+  }
+
+  // Memory Data Access Control
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+      lcd_panel->madctl_val,
+  }, 1);
+  // Interface Pixel Format
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_COLMOD, (uint8_t[]) {
+      lcd_panel->colmod_cal,
+  }, 1);
+
+  // Turn on display
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_DISPON, NULL, 0);
+
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  assert((x_start < x_end) && (y_start < y_end) && "start position must be smaller than end position");
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+
+  x_start += lcd_panel->x_gap;
+  x_end += lcd_panel->x_gap;
+  y_start += lcd_panel->y_gap;
+  y_end += lcd_panel->y_gap;
+
+  // define an area of frame memory where MCU can access
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_CASET, (uint8_t[]) {
+      (x_start >> 8) & 0xFF,
+      x_start & 0xFF,
+      ((x_end - 1) >> 8) & 0xFF,
+      (x_end - 1) & 0xFF,
+  }, 4);
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_RASET, (uint8_t[]) {
+      (y_start >> 8) & 0xFF,
+      y_start & 0xFF,
+      ((y_end - 1) >> 8) & 0xFF,
+      (y_end - 1) & 0xFF,
+  }, 4);
+
+  // transfer frame buffer
+  size_t len = (x_end - x_start) * (y_end - y_start) * lcd_panel->bits_per_pixel / 8;
+  esp_lcd_panel_io_tx_color(io, LCD_CMD_RAMWR, color_data, len);
+
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_invert_color(esp_lcd_panel_t *panel, bool invert_color_data) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  int command = 0;
+  if (invert_color_data) {
+    command = LCD_CMD_INVON;
+  } else {
+    command = LCD_CMD_INVOFF;
+  }
+  esp_lcd_panel_io_tx_param(io, command, NULL, 0);
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  if (mirror_x) {
+    lcd_panel->madctl_val |= LCD_CMD_MX_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MX_BIT;
+  }
+  if (mirror_y) {
+    lcd_panel->madctl_val |= LCD_CMD_MY_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MY_BIT;
+  }
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+    lcd_panel->madctl_val
+  }, 1);
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_swap_xy(esp_lcd_panel_t *panel, bool swap_axes) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  if (swap_axes) {
+    lcd_panel->madctl_val |= LCD_CMD_MV_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MV_BIT;
+  }
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+    lcd_panel->madctl_val
+  }, 1);
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  lcd_panel->x_gap = x_gap;
+  lcd_panel->y_gap = y_gap;
+  return ESP_OK;
+}
+
+static esp_err_t lcd_panel_disp_on_off(esp_lcd_panel_t *panel, bool off) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  int command = 0;
+  if (off) {
+    command = LCD_CMD_DISPOFF;
+  } else {
+    command = LCD_CMD_DISPON;
+  }
+  esp_lcd_panel_io_tx_param(io, command, NULL, 0);
+  return ESP_OK;
 }

--- a/hardware/common/components/ili9341/ili9341.h
+++ b/hardware/common/components/ili9341/ili9341.h
@@ -1,11 +1,8 @@
 /**
- * @file lv_templ.h
- *
+ * @file ili9341.h
  */
 
-#ifndef ILI9341_H
-#define ILI9341_H
-
+#pragma once
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,7 +12,14 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 #include <stdint.h>
+
 #include "esp_err.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_rgb.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_interface.h"
+#include "esp_lcd_panel_commands.h"
 
 /*********************
  *      DEFINES
@@ -24,21 +28,15 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-typedef struct {
-  int8_t rst_pin;
-  int8_t dc_pin;
-} ili9341_config_t;
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
+esp_err_t esp_lcd_new_panel_ili9341(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel);
 
-esp_err_t ili9341_init(const ili9341_config_t *config);
-void ili9341_set_invert_color(bool invert);
-void ili9341_set_orientation(uint8_t orientation);
-void ili9341_draw_bitmap(int x_start, int y_start, int x_end, int y_end, const void *color_data);
-void ili9341_sleep_in(void);
-void ili9341_sleep_out(void);
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
 
 /**********************
  *      MACROS
@@ -47,5 +45,3 @@ void ili9341_sleep_out(void);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
-
-#endif /*ILI9341_H*/

--- a/hardware/common/components/ili9341/ili9341.h
+++ b/hardware/common/components/ili9341/ili9341.h
@@ -15,7 +15,6 @@ extern "C" {
 
 #include "esp_err.h"
 #include "esp_lcd_panel_io.h"
-#include "esp_lcd_panel_rgb.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_panel_interface.h"

--- a/hardware/common/components/st7796/st7796.c
+++ b/hardware/common/components/st7796/st7796.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <sys/cdefs.h>
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include <driver/gpio.h>
@@ -18,278 +19,269 @@
  **********************/
 
 typedef struct {
-    esp_lcd_panel_t base;
-    esp_lcd_panel_io_handle_t io;
-    int reset_gpio_num;
-    bool reset_level;
-    int x_gap;
-    int y_gap;
-    unsigned int bits_per_pixel;
-    uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
-    uint8_t colmod_cal; // save current value of LCD_CMD_COLMOD register
-} st7796_panel_t;
+  esp_lcd_panel_t base;
+  esp_lcd_panel_io_handle_t io;
+  int reset_gpio_num;
+  bool reset_level;
+  int x_gap;
+  int y_gap;
+  unsigned int bits_per_pixel;
+  uint8_t madctl_val; // save current value of LCD_CMD_MADCTL register
+  uint8_t colmod_cal; // save current value of LCD_CMD_COLMOD register
+} lcd_panel_t;
 
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
 
-static esp_err_t panel_st7796_del(esp_lcd_panel_t *panel);
-static esp_err_t panel_st7796_reset(esp_lcd_panel_t *panel);
-static esp_err_t panel_st7796_init(esp_lcd_panel_t *panel);
-static esp_err_t panel_st7796_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data);
-static esp_err_t panel_st7796_invert_color(esp_lcd_panel_t *panel, bool invert_color_data);
-static esp_err_t panel_st7796_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
-static esp_err_t panel_st7796_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
-static esp_err_t panel_st7796_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
-static esp_err_t panel_st7796_disp_off(esp_lcd_panel_t *panel, bool off);
+static esp_err_t lcd_panel_del(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_reset(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_init(esp_lcd_panel_t *panel);
+static esp_err_t lcd_panel_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data);
+static esp_err_t lcd_panel_invert_color(esp_lcd_panel_t *panel, bool invert_color_data);
+static esp_err_t lcd_panel_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y);
+static esp_err_t lcd_panel_swap_xy(esp_lcd_panel_t *panel, bool swap_axes);
+static esp_err_t lcd_panel_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap);
+static esp_err_t lcd_panel_disp_on_off(esp_lcd_panel_t *panel, bool off);
 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
 
-esp_err_t esp_lcd_new_panel_st7796(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel)
-{
-    esp_err_t ret = ESP_OK;
-    st7796_panel_t *st7796 = NULL;
-    ESP_GOTO_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, err, "", "invalid argument");
-    st7796 = calloc(1, sizeof(st7796_panel_t));
-    ESP_GOTO_ON_FALSE(st7796, ESP_ERR_NO_MEM, err, "", "no mem for st7796 panel");
+esp_err_t esp_lcd_new_panel_st7796(const esp_lcd_panel_io_handle_t io, const esp_lcd_panel_dev_config_t *panel_dev_config, esp_lcd_panel_handle_t *ret_panel) {
+  esp_err_t ret = ESP_OK;
+  lcd_panel_t *lcd_panel = NULL;
+  ESP_GOTO_ON_FALSE(io && panel_dev_config && ret_panel, ESP_ERR_INVALID_ARG, err, "", "invalid argument");
+  lcd_panel = calloc(1, sizeof(lcd_panel_t));
+  ESP_GOTO_ON_FALSE(lcd_panel, ESP_ERR_NO_MEM, err, "", "no mem for st7796 panel");
 
-    if (panel_dev_config->reset_gpio_num >= 0) {
-        gpio_config_t io_conf = {
-            .mode = GPIO_MODE_OUTPUT,
-            .pin_bit_mask = 1ULL << panel_dev_config->reset_gpio_num,
-        };
-        ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, "", "configure GPIO for RST line failed");
-    }
+  if (panel_dev_config->reset_gpio_num >= 0) {
+    gpio_config_t io_conf = {
+        .mode = GPIO_MODE_OUTPUT,
+        .pin_bit_mask = 1ULL << panel_dev_config->reset_gpio_num,
+    };
+    ESP_GOTO_ON_ERROR(gpio_config(&io_conf), err, "", "configure GPIO for RST line failed");
+  }
 
-    switch (panel_dev_config->color_space) {
+  switch (panel_dev_config->color_space) {
     case ESP_LCD_COLOR_SPACE_RGB:
-        st7796->madctl_val = 0;
-        break;
+      lcd_panel->madctl_val = 0;
+      break;
     case ESP_LCD_COLOR_SPACE_BGR:
-        st7796->madctl_val |= LCD_CMD_BGR_BIT;
-        break;
+      lcd_panel->madctl_val |= LCD_CMD_BGR_BIT;
+      break;
     default:
-        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported color space");
-        break;
-    }
+      ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported color space");
+      break;
+  }
 
-    switch (panel_dev_config->bits_per_pixel) {
+  switch (panel_dev_config->bits_per_pixel) {
     case 16:
-        st7796->colmod_cal = 0x55;
-        break;
+      lcd_panel->colmod_cal = 0x55;
+      break;
     case 18:
-        st7796->colmod_cal = 0x66;
-        break;
+      lcd_panel->colmod_cal = 0x66;
+      break;
     default:
-        ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported pixel width");
-        break;
-    }
+      ESP_GOTO_ON_FALSE(false, ESP_ERR_NOT_SUPPORTED, err, "", "unsupported pixel width");
+      break;
+  }
 
-    st7796->io = io;
-    st7796->bits_per_pixel = panel_dev_config->bits_per_pixel;
-    st7796->reset_gpio_num = panel_dev_config->reset_gpio_num;
-    st7796->reset_level = panel_dev_config->flags.reset_active_high;
-    st7796->base.del = panel_st7796_del;
-    st7796->base.reset = panel_st7796_reset;
-    st7796->base.init = panel_st7796_init;
-    st7796->base.draw_bitmap = panel_st7796_draw_bitmap;
-    st7796->base.invert_color = panel_st7796_invert_color;
-    st7796->base.set_gap = panel_st7796_set_gap;
-    st7796->base.mirror = panel_st7796_mirror;
-    st7796->base.swap_xy = panel_st7796_swap_xy;
-    st7796->base.disp_on_off = panel_st7796_disp_off;
-    *ret_panel = &(st7796->base);
-    esp3d_log("new st7796 panel @%p", st7796);
+  lcd_panel->io = io;
+  lcd_panel->bits_per_pixel = panel_dev_config->bits_per_pixel;
+  lcd_panel->reset_gpio_num = panel_dev_config->reset_gpio_num;
+  lcd_panel->reset_level = panel_dev_config->flags.reset_active_high;
+  lcd_panel->base.del = lcd_panel_del;
+  lcd_panel->base.reset = lcd_panel_reset;
+  lcd_panel->base.init = lcd_panel_init;
+  lcd_panel->base.draw_bitmap = lcd_panel_draw_bitmap;
+  lcd_panel->base.invert_color = lcd_panel_invert_color;
+  lcd_panel->base.set_gap = lcd_panel_set_gap;
+  lcd_panel->base.mirror = lcd_panel_mirror;
+  lcd_panel->base.swap_xy = lcd_panel_swap_xy;
+  lcd_panel->base.disp_on_off = lcd_panel_disp_on_off;
+  *ret_panel = &(lcd_panel->base);
+  esp3d_log("new st7796 panel @%p", lcd_panel);
 
-    return ESP_OK;
+  return ESP_OK;
 
 err:
-    if (st7796) {
-        if (panel_dev_config->reset_gpio_num >= 0) {
-            gpio_reset_pin(panel_dev_config->reset_gpio_num);
-        }
-        free(st7796);
+  if (lcd_panel) {
+    if (panel_dev_config->reset_gpio_num >= 0) {
+      gpio_reset_pin(panel_dev_config->reset_gpio_num);
     }
-    return ret;
+    free(lcd_panel);
+  }
+  return ret;
 }
 
 /**********************
  *   Static FUNCTIONS
  **********************/
 
-static esp_err_t panel_st7796_del(esp_lcd_panel_t *panel)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
+static esp_err_t lcd_panel_del(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
 
-    if (st7796->reset_gpio_num >= 0) {
-        gpio_reset_pin(st7796->reset_gpio_num);
-    }
-    esp3d_log("del st7796 panel @%p", st7796);
-    free(st7796);
-    return ESP_OK;
+  if (lcd_panel->reset_gpio_num >= 0) {
+    gpio_reset_pin(lcd_panel->reset_gpio_num);
+  }
+  esp3d_log("del st7796 panel @%p", lcd_panel);
+  free(lcd_panel);
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_reset(esp_lcd_panel_t *panel)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
+static esp_err_t lcd_panel_reset(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
 
-    // perform hardware reset
-    if (st7796->reset_gpio_num >= 0) {
-        gpio_set_level(st7796->reset_gpio_num, st7796->reset_level);
-        vTaskDelay(pdMS_TO_TICKS(10));
-        gpio_set_level(st7796->reset_gpio_num, !st7796->reset_level);
-        vTaskDelay(pdMS_TO_TICKS(10));
-    } else { // perform software reset
-        esp_lcd_panel_io_tx_param(io, LCD_CMD_SWRESET, NULL, 0);
-        vTaskDelay(pdMS_TO_TICKS(20)); // spec, wait at least 5m before sending new command
-    }
+  // perform hardware reset
+  if (lcd_panel->reset_gpio_num >= 0) {
+    gpio_set_level(lcd_panel->reset_gpio_num, lcd_panel->reset_level);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    gpio_set_level(lcd_panel->reset_gpio_num, !lcd_panel->reset_level);
+    vTaskDelay(pdMS_TO_TICKS(10));
+  } else { // perform software reset
+    esp_lcd_panel_io_tx_param(io, LCD_CMD_SWRESET, NULL, 0);
+    vTaskDelay(pdMS_TO_TICKS(20)); // spec, wait at least 5 ms. before sending new command
+  }
 
-    return ESP_OK;
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_init(esp_lcd_panel_t *panel)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
+static esp_err_t lcd_panel_init(esp_lcd_panel_t *panel) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
 
-    // LCD goes into sleep mode and display will be turned off after power on reset, exit sleep mode first
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_SLPOUT, NULL, 0);
-    vTaskDelay(pdMS_TO_TICKS(100));
+  // LCD goes into sleep mode and display will be turned off after power on reset, exit sleep mode first
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_SLPOUT, NULL, 0);
+  vTaskDelay(pdMS_TO_TICKS(100));
+
+  // Memory Data Access Control
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+      lcd_panel->madctl_val,
+  }, 1);
+  // Interface Pixel Format
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_COLMOD, (uint8_t[]) {
+      lcd_panel->colmod_cal,
+  }, 1);
+
+  // Command Set Control - Enable Extension Command 2 part I
+  esp_lcd_panel_io_tx_param(io, 0xF0, (uint8_t[]){0xC3}, 1);
+
+  // Positive Gamma Control
+  esp_lcd_panel_io_tx_param(io, 0xE0, (uint8_t[]) {
+      0xF0, 0x09, 0x0B, 0x06, 0x04, 0x15, 0x2F,
+      0x54, 0x42, 0x3C, 0x17, 0x14, 0x18, 0x1B
+  }, 14);
+  // Negative Gamma Control
+  esp_lcd_panel_io_tx_param(io, 0xE1, (uint8_t[]) {
+      0xE0, 0x09, 0x0B, 0x06, 0x04, 0x03, 0x2B,
+      0x43, 0x42, 0x3B, 0x16, 0x14, 0x17, 0x1B
+  }, 14);
     
-    // Memory Data Access Control
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
-        st7796->madctl_val,
-    }, 1);
-    // Interface Pixel Format
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_COLMOD, (uint8_t[]) {
-        st7796->colmod_cal,
-    }, 1);
+  // Command Set Control - Disable Extension Command 2 part I
+  esp_lcd_panel_io_tx_param(io, 0xF0, (uint8_t[]){0x3C}, 1);
 
-    // Command Set Control - Enable Extension Command 2 part I
-    esp_lcd_panel_io_tx_param(io, 0xF0, (uint8_t[]){0xC3}, 1);
-    
-    // Positive Gamma Control
-    esp_lcd_panel_io_tx_param(io, 0xE0, (uint8_t[]) {
-        0xF0, 0x09, 0x0B, 0x06, 0x04, 0x15, 0x2F,
-        0x54, 0x42, 0x3C, 0x17, 0x14, 0x18, 0x1B
-    }, 14);
-    // Negative Gamma Control
-    esp_lcd_panel_io_tx_param(io, 0xE1, (uint8_t[]) {
-        0xE0, 0x09, 0x0B, 0x06, 0x04, 0x03, 0x2B,
-        0x43, 0x42, 0x3B, 0x16, 0x14, 0x17, 0x1B
-    }, 14);
-    
-    // Command Set Control - Disable Extension Command 2 part I
-    esp_lcd_panel_io_tx_param(io, 0xF0, (uint8_t[]){0x3C}, 1);
+  // Turn on display
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_DISPON, NULL, 0);
 
-    // Turn on display
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_DISPON, NULL, 0);
-
-    return ESP_OK;
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    assert((x_start < x_end) && (y_start < y_end) && "start position must be smaller than end position");
-    esp_lcd_panel_io_handle_t io = st7796->io;
+static esp_err_t lcd_panel_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, int x_end, int y_end, const void *color_data) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  assert((x_start < x_end) && (y_start < y_end) && "start position must be smaller than end position");
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
 
-    x_start += st7796->x_gap;
-    x_end += st7796->x_gap;
-    y_start += st7796->y_gap;
-    y_end += st7796->y_gap;
+  x_start += lcd_panel->x_gap;
+  x_end += lcd_panel->x_gap;
+  y_start += lcd_panel->y_gap;
+  y_end += lcd_panel->y_gap;
 
-    // define an area of frame memory where MCU can access
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_CASET, (uint8_t[]) {
-        (x_start >> 8) & 0xFF,
-        x_start & 0xFF,
-        ((x_end - 1) >> 8) & 0xFF,
-        (x_end - 1) & 0xFF,
-    }, 4);
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_RASET, (uint8_t[]) {
-        (y_start >> 8) & 0xFF,
-        y_start & 0xFF,
-        ((y_end - 1) >> 8) & 0xFF,
-        (y_end - 1) & 0xFF,
-    }, 4);
-    // transfer frame buffer
-    size_t len = (x_end - x_start) * (y_end - y_start) * st7796->bits_per_pixel / 8;
-    esp_lcd_panel_io_tx_color(io, LCD_CMD_RAMWR, color_data, len);
+  // define an area of frame memory where MCU can access
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_CASET, (uint8_t[]) {
+      (x_start >> 8) & 0xFF,
+      x_start & 0xFF,
+      ((x_end - 1) >> 8) & 0xFF,
+      (x_end - 1) & 0xFF,
+  }, 4);
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_RASET, (uint8_t[]) {
+      (y_start >> 8) & 0xFF,
+      y_start & 0xFF,
+      ((y_end - 1) >> 8) & 0xFF,
+      (y_end - 1) & 0xFF,
+  }, 4);
 
-    return ESP_OK;
+  // transfer frame buffer
+  size_t len = (x_end - x_start) * (y_end - y_start) * lcd_panel->bits_per_pixel / 8;
+  esp_lcd_panel_io_tx_color(io, LCD_CMD_RAMWR, color_data, len);
+
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_invert_color(esp_lcd_panel_t *panel, bool invert_color_data)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
-    int command = 0;
-    if (invert_color_data) {
-        command = LCD_CMD_INVON;
-    } else {
-        command = LCD_CMD_INVOFF;
-    }
-    esp_lcd_panel_io_tx_param(io, command, NULL, 0);
-    return ESP_OK;
+static esp_err_t lcd_panel_invert_color(esp_lcd_panel_t *panel, bool invert_color_data) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  int command = 0;
+  if (invert_color_data) {
+    command = LCD_CMD_INVON;
+  } else {
+    command = LCD_CMD_INVOFF;
+  }
+  esp_lcd_panel_io_tx_param(io, command, NULL, 0);
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
-    if (mirror_x) {
-        st7796->madctl_val |= LCD_CMD_MX_BIT;
-    } else {
-        st7796->madctl_val &= ~LCD_CMD_MX_BIT;
-    }
-    if (mirror_y) {
-        st7796->madctl_val |= LCD_CMD_MY_BIT;
-    } else {
-        st7796->madctl_val &= ~LCD_CMD_MY_BIT;
-    }
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
-        st7796->madctl_val
-    }, 1);
-    return ESP_OK;
+static esp_err_t lcd_panel_mirror(esp_lcd_panel_t *panel, bool mirror_x, bool mirror_y) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  if (mirror_x) {
+    lcd_panel->madctl_val |= LCD_CMD_MX_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MX_BIT;
+  }
+  if (mirror_y) {
+    lcd_panel->madctl_val |= LCD_CMD_MY_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MY_BIT;
+  }
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+    lcd_panel->madctl_val
+  }, 1);
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_swap_xy(esp_lcd_panel_t *panel, bool swap_axes)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
-    if (swap_axes) {
-        st7796->madctl_val |= LCD_CMD_MV_BIT;
-    } else {
-        st7796->madctl_val &= ~LCD_CMD_MV_BIT;
-    }
-    esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
-        st7796->madctl_val
-    }, 1);
-    return ESP_OK;
+static esp_err_t lcd_panel_swap_xy(esp_lcd_panel_t *panel, bool swap_axes) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  if (swap_axes) {
+    lcd_panel->madctl_val |= LCD_CMD_MV_BIT;
+  } else {
+    lcd_panel->madctl_val &= ~LCD_CMD_MV_BIT;
+  }
+  esp_lcd_panel_io_tx_param(io, LCD_CMD_MADCTL, (uint8_t[]) {
+    lcd_panel->madctl_val
+  }, 1);
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    st7796->x_gap = x_gap;
-    st7796->y_gap = y_gap;
-    return ESP_OK;
+static esp_err_t lcd_panel_set_gap(esp_lcd_panel_t *panel, int x_gap, int y_gap) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  lcd_panel->x_gap = x_gap;
+  lcd_panel->y_gap = y_gap;
+  return ESP_OK;
 }
 
-static esp_err_t panel_st7796_disp_off(esp_lcd_panel_t *panel, bool off)
-{
-    st7796_panel_t *st7796 = __containerof(panel, st7796_panel_t, base);
-    esp_lcd_panel_io_handle_t io = st7796->io;
-    int command = 0;
-    if (off) {
-        command = LCD_CMD_DISPOFF;
-    } else {
-        command = LCD_CMD_DISPON;
-    }
-    esp_lcd_panel_io_tx_param(io, command, NULL, 0);
-    return ESP_OK;
+static esp_err_t lcd_panel_disp_on_off(esp_lcd_panel_t *panel, bool off) {
+  lcd_panel_t *lcd_panel = __containerof(panel, lcd_panel_t, base);
+  esp_lcd_panel_io_handle_t io = lcd_panel->io;
+  int command = 0;
+  if (off) {
+    command = LCD_CMD_DISPOFF;
+  } else {
+    command = LCD_CMD_DISPON;
+  }
+  esp_lcd_panel_io_tx_param(io, command, NULL, 0);
+  return ESP_OK;
 }

--- a/hardware/common/components/st7796/st7796.h
+++ b/hardware/common/components/st7796/st7796.h
@@ -15,7 +15,6 @@ extern "C" {
 
 #include "esp_err.h"
 #include "esp_lcd_panel_io.h"
-#include "esp_lcd_panel_rgb.h"
 #include "esp_lcd_panel_vendor.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_panel_interface.h"


### PR DESCRIPTION
This PR converts the /hardware/common/ili9341 driver to use esp_lcd like the other drivers for better consistency.  This also eliminates the need for the disp_spi component, since esp_lcd has built-in support for queued spi transactions.  I didn't remove disp_spi (yet) in case we still need it in the future.

Interestingly, after this change the only difference between the ili9341 and st7796 driver is the vendor specific initialization code, so we might eventually want to refactor further.

I have re-tested ESP32_2432S028R both without and with PSRAM to make sure there were no regressions after this change.